### PR TITLE
Fix hero showcase layout on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -557,6 +557,44 @@ button:focus, input:focus, select:focus, textarea:focus {
   text-decoration: none;
 }
 
+/* ----- HERO SHOWCASE (icone) ----- */
+.events-showcase,
+.about-showcase,
+.contact-showcase {
+  display: grid;
+  gap: var(--space-6);
+  justify-content: center;
+}
+
+@media (min-width: 992px) {
+  .events-showcase,
+  .about-showcase,
+  .contact-showcase {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 576px) and (max-width: 991px) {
+  .events-showcase,
+  .about-showcase,
+  .contact-showcase {
+    grid-template-columns: repeat(2, 140px);
+  }
+}
+
+@media (max-width: 575px) {
+  .events-showcase,
+  .about-showcase,
+  .contact-showcase {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-4);
+  }
+  .showcase-item {
+    width: 100%;
+    max-width: 110px;
+  }
+}
+
 /* ===== SERVICES SECTION ===== */
 .services {
   padding: var(--space-20) 0;
@@ -1319,20 +1357,6 @@ button:focus, input:focus, select:focus, textarea:focus {
     font-size: 0.7rem;
   }
 
-  .about-showcase,
-  .events-showcase,
-  .contact-showcase {
-    grid-template-columns: 1fr;
-    max-width: 200px;
-    gap: 0.75rem;
-  }
-
-  .showcase-circle,
-  .showcase-item,
-  .contact-method {
-    width: 80px;
-    height: 80px;
-  }
 
   /* Touch targets */
   .nav-link,


### PR DESCRIPTION
## Summary
- adjust hero showcase grid for events/about/contact hero sections
- remove old mobile-specific styles

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686c04378324832ba999c8dc1709f7ff